### PR TITLE
CI: Build with Clang on Windows

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -26,7 +26,7 @@ jobs:
         c_compiler: [gcc, clang, cl]
         include:
           - os: windows-latest
-            c_compiler: cl
+            c_compiler: clang
             cpp_compiler: cl
           - os: ubuntu-latest
             c_compiler: gcc
@@ -37,8 +37,6 @@ jobs:
         exclude:
           - os: windows-latest
             c_compiler: gcc
-          - os: windows-latest
-            c_compiler: clang
           - os: ubuntu-latest
             c_compiler: cl
 


### PR DESCRIPTION
MSVC is not C23 compliant.